### PR TITLE
fix: fixed namespace in scheduler kustomization

### DIFF
--- a/lfc-scheduler/manifests/install/kustomization.yaml
+++ b/lfc-scheduler/manifests/install/kustomization.yaml
@@ -1,19 +1,21 @@
+namespace: keptn-lifecycle-controller-system
+
 resources:
-  - base/deployment.yaml
-  - base/rbac.yaml
-  - base/serviceaccount.yaml
+- base/deployment.yaml
+- base/rbac.yaml
+- base/serviceaccount.yaml
 
 generatorOptions:
   disableNameSuffixHash: true
 
 configMapGenerator:
-  - files:
-      - base/scheduler-config.yaml
-    name: scheduler-config
+- files:
+  - base/scheduler-config.yaml
+  name: scheduler-config
 
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
-  - name: klfc-scheduler
-    newName: ghcr.io/keptn-sandbox/lfc-scheduler
-    newTag: latest
+- name: klfc-scheduler
+  newName: ghcr.io/keptn-sandbox/lfc-scheduler
+  newTag: latest


### PR DESCRIPTION
As this led to problems when deploying outside of the keptn-lifecycle-controller-system namespace

Signed-off-by: Thomas Schuetz <thomas.schuetz@dynatrace.com>