### PR TITLE
fix: scheduler config plugin configuration

### DIFF
--- a/lfc-scheduler/manifests/install/base/scheduler-config.yaml
+++ b/lfc-scheduler/manifests/install/base/scheduler-config.yaml
@@ -2,12 +2,11 @@ apiVersion: kubescheduler.config.k8s.io/v1beta3
 kind: KubeSchedulerConfiguration
 leaderElection:
   leaderElect: false
+clientConnection:
+  kubeconfig: "/etc/kubernetes/scheduler.conf"
 profiles:
-  # Compose all plugins in one profile
   - schedulerName: keptn-scheduler
     plugins:
-      multiPoint:
+      permit:
         enabled:
-          - name: "KLCPermit"
-        disabled: []
-    pluginConfig: {}
+          - name: KLCPermit

--- a/lfc-scheduler/manifests/install/base/scheduler-config.yaml
+++ b/lfc-scheduler/manifests/install/base/scheduler-config.yaml
@@ -2,11 +2,10 @@ apiVersion: kubescheduler.config.k8s.io/v1beta3
 kind: KubeSchedulerConfiguration
 leaderElection:
   leaderElect: false
-clientConnection:
-  kubeconfig: "/etc/kubernetes/scheduler.conf"
 profiles:
+  # Compose all plugins in one profile
   - schedulerName: keptn-scheduler
     plugins:
       permit:
         enabled:
-          - name: KLCPermit
+          - name: "KLCPermit"


### PR DESCRIPTION
Using the current configuration for the `KubeSchedulerConfiguration` resulted in the following error in the scheduler:

```
command failed" err="json: cannot unmarshal object into Go struct field KubeSchedulerProfile.profiles.pluginConfig of type []v1beta3.PluginConfig
```

Changing the value to what we previously had in the scheduler config seems to solve this.

Signed-off-by: Florian Bacher <florian.bacher@dynatrace.com>