### PR TITLE
ci: Add lfc-scheduler manifest to release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,7 @@ jobs:
           cd ../lfc-scheduler
           go mod tidy
           make build-and-push-image TAG=${{ steps.get_version.outputs.VERSION }}
+          make release-manifests TAG=${{ steps.get_version.outputs.VERSION }}
           cd ../operator
           go mod tidy
           make build-and-push-image TAG=${{ steps.get_version.outputs.VERSION }}
@@ -34,4 +35,6 @@ jobs:
       - name: Release
         uses: softprops/action-gh-release@v1
         with:
-          files: operator/config/rendered/release.yaml
+          files: |
+            lfc-scheduler/config/rendered/release.yaml
+            operator/config/rendered/release.yaml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,9 +32,9 @@ jobs:
           go mod tidy
           make build-and-push-image TAG=${{ steps.get_version.outputs.VERSION }}
           make controller-gen release-manifests TAG=${{ steps.get_version.outputs.VERSION }}
+          cd ..
+          cat fc-scheduler/config/rendered/release.yaml operator/config/rendered/release.yaml > manifest.yaml
       - name: Release
         uses: softprops/action-gh-release@v1
         with:
-          files: |
-            lfc-scheduler/config/rendered/release.yaml
-            operator/config/rendered/release.yaml
+          files: manifest.yaml


### PR DESCRIPTION
Signed-off-by: Philipp Hinteregger <philipp.hinteregger@dynatrace.com>
Closes #34 

## This PR

- Adds the manifest file from lfc-scheduler to the release