### PR TITLE
fix: Added namespace to task definition for podtato head example

### DIFF
--- a/examples/podtatohead-deployment/pre-deployment-tasks.yaml
+++ b/examples/podtatohead-deployment/pre-deployment-tasks.yaml
@@ -2,6 +2,7 @@ apiVersion: lifecycle.keptn.sh/v1alpha1
 kind: KeptnTaskDefinition
 metadata:
   name: pre-deployment-hello
+  namespace: podtato-kubectl
 spec:
   function:
     inline:


### PR DESCRIPTION
With the namespace added, the demo can simply be executed using `kubectl apply -f .` in the `examples/podtatohead-deployment` directory
Signed-off-by: Florian Bacher <florian.bacher@dynatrace.com>