### PR TITLE
ci: Skip docker push steps if the PR is from a fork

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -171,20 +171,26 @@ jobs:
     - name: Build Docker Images
       working-directory: ./${{ matrix.config.working-dir }}
       run: |
-        make build-and-push-image TAG=dev-${{ env.DATETIME }}
+        make release-image TAG=dev-${{ env.DATETIME }}
+
+    - name: Push Docker Images
+      if: ( github.actor != 'renovate[bot]' && github.actor != 'dependabot[bot]' ) && github.event.pull_request.head.repo.full_name == github.repository
+      working-directory: ./${{ matrix.config.working-dir }}
+      run: |
+        make push-release-images TAG=dev-${{ env.DATETIME }}
 
     - name: Install controller-gen
-      if: matrix.config.artifact == 'keptn-lifecycle-operator'
+      if: matrix.config.artifact == 'keptn-lifecycle-operator' && ( github.actor != 'renovate[bot]' && github.actor != 'dependabot[bot]' ) && github.event.pull_request.head.repo.full_name == github.repository
       working-directory: ./${{ matrix.config.working-dir }}
       run: make controller-gen
 
     - name: Generate release.yaml
-      if: matrix.config.artifact != 'functions-runtime'
+      if: matrix.config.artifact != 'functions-runtime' && ( github.actor != 'renovate[bot]' && github.actor != 'dependabot[bot]' ) && github.event.pull_request.head.repo.full_name == github.repository
       working-directory: ./${{ matrix.config.working-dir }}
       run: make release-manifests TAG=dev-${{ env.DATETIME }}
 
     - name: Upload release.yaml
-      if: matrix.config.artifact != 'functions-runtime'
+      if: matrix.config.artifact != 'functions-runtime' && ( github.actor != 'renovate[bot]' && github.actor != 'dependabot[bot]' ) && github.event.pull_request.head.repo.full_name == github.repository
       uses: actions/upload-artifact@v3
       with:
         name: ${{ matrix.config.artifact }}-manifest


### PR DESCRIPTION
Signed-off-by: Philipp Hinteregger <philipp.hinteregger@dynatrace.com>

## This PR
- Splits the Docker build and push steps into two separate steps
- Skips the following steps in the CI pipeline if the PR is from a fork
  - Push Docker Images
  - Install controller-gen
  - Generate release.yaml
  - Upload release.yaml