### PR TITLE
ci: Disable ARM builds for now

### DIFF
--- a/functions-runtime/Makefile
+++ b/functions-runtime/Makefile
@@ -19,7 +19,7 @@ VERSION=$(shell echo $(RELEASE_VERSION) | awk -F - '{print $$2}')
 build-and-push-image: release-image push-release-images
 
 .PHONY: release-image
-release-image: release-image.amd64 release-image.arm64v8
+release-image: release-image.amd64
 
 .PHONY: release-image.amd64
 release-image.amd64: clean
@@ -30,7 +30,7 @@ release-image.arm64v8: clean
 	docker build  --load --no-cache --build-arg ARCH="arm64v8" -t $(RELEASE_REGISTRY)/$(RELEASE_IMAGE)-arm64 .
 
 .PHONY: push-release-images
-push-release-images: release-image.amd64 release-image.arm64v8
+push-release-images: release-image.amd64
 	#gcloud auth configure-docker
 	for arch in $(ARCHS); do \
 		docker push $(RELEASE_REGISTRY)/$(RELEASE_IMAGE)-$${arch} ;\

--- a/functions-runtime/Makefile
+++ b/functions-runtime/Makefile
@@ -5,7 +5,7 @@ RELEASE_VERSION?=$(shell date +%Y%m%d%s)-v0.24.3#$(shell git describe --tags --m
 TAG?=latest
 RELEASE_IMAGE:=functions-runtime:$(TAG)
 
-ARCHS = amd64 arm64
+ARCHS = amd64
 COMMONENVVAR=GOOS=$(shell uname -s | tr A-Z a-z)
 BUILDENVVAR=CGO_ENABLED=0
 
@@ -30,7 +30,7 @@ release-image.arm64v8: clean
 	docker build  --load --no-cache --build-arg ARCH="arm64v8" -t $(RELEASE_REGISTRY)/$(RELEASE_IMAGE)-arm64 .
 
 .PHONY: push-release-images
-push-release-images: release-image.amd64
+push-release-images:
 	#gcloud auth configure-docker
 	for arch in $(ARCHS); do \
 		docker push $(RELEASE_REGISTRY)/$(RELEASE_IMAGE)-$${arch} ;\

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -8,7 +8,7 @@ RELEASE_VERSION?=$(shell date +%Y%m%d%s)-v0.24.3#$(shell git describe --tags --m
 TAG?=latest
 RELEASE_IMAGE:=keptn-lifecycle-operator:$(TAG)
 
-ARCHS = amd64 arm64
+ARCHS = amd64
 COMMONENVVAR=GOOS=$(shell uname -s | tr A-Z a-z)
 BUILDENVVAR=CGO_ENABLED=0
 
@@ -169,7 +169,7 @@ release-image.arm64v8: clean
 	docker build --load --build-arg ARCH="arm64v8" --build-arg RELEASE_VERSION="$(RELEASE_VERSION)" -t $(RELEASE_REGISTRY)/$(RELEASE_IMAGE)-arm64 .
 
 .PHONY: push-release-images
-push-release-images: release-image.amd64
+push-release-images:
 	#gcloud auth configure-docker
 	for arch in $(ARCHS); do \
 		docker push $(RELEASE_REGISTRY)/$(RELEASE_IMAGE)-$${arch} ;\

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -158,7 +158,7 @@ $(ENVTEST): $(LOCALBIN)
 build-and-push-image: release-image push-release-images
 
 .PHONY: release-image
-release-image: release-image.amd64 release-image.arm64v8
+release-image: release-image.amd64
 
 .PHONY: release-image.amd64
 release-image.amd64: clean
@@ -169,7 +169,7 @@ release-image.arm64v8: clean
 	docker build --load --build-arg ARCH="arm64v8" --build-arg RELEASE_VERSION="$(RELEASE_VERSION)" -t $(RELEASE_REGISTRY)/$(RELEASE_IMAGE)-arm64 .
 
 .PHONY: push-release-images
-push-release-images: release-image.amd64 release-image.arm64v8
+push-release-images: release-image.amd64
 	#gcloud auth configure-docker
 	for arch in $(ARCHS); do \
 		docker push $(RELEASE_REGISTRY)/$(RELEASE_IMAGE)-$${arch} ;\
@@ -191,7 +191,7 @@ clean:
 build-and-push-local: release-local
 
 .PHONY: release-local
-release-local: release-local.amd64 release-local.arm64v8
+release-local: release-local.amd64
 	for arch in $(ARCHS); do \
 			docker push $(RELEASE_REGISTRY)/$(RELEASE_IMAGE)-$${arch} ;\
 		done

--- a/scheduler/Makefile
+++ b/scheduler/Makefile
@@ -58,7 +58,7 @@ build: build-scheduler
 build.amd64: build-controller.amd64 build-scheduler.amd64
 
 .PHONY: build.arm64v8
-build.arm64v8: build-controller.arm64v8
+build.arm64v8: build-controller.arm64v8 build-scheduler.arm64v8
 
 .PHONY: build-controller
 build-controller:

--- a/scheduler/Makefile
+++ b/scheduler/Makefile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARCHS = amd64 arm64
+ARCHS = amd64
 COMMONENVVAR=GOOS=$(shell uname -s | tr A-Z a-z)
 BUILDENVVAR=CGO_ENABLED=0
 TAG?=latest
@@ -125,7 +125,7 @@ release-image.arm64v8: clean
 	docker build --load --build-arg ARCH="arm64v8" --build-arg RELEASE_VERSION="$(RELEASE_VERSION)" -t $(RELEASE_REGISTRY)/$(RELEASE_IMAGE)-arm64 .
 
 .PHONY: push-release-images
-push-release-images: release-image.amd64
+push-release-images:
 	for arch in $(ARCHS); do \
 		docker push $(RELEASE_REGISTRY)/$(RELEASE_IMAGE)-$${arch} ;\
 	done

--- a/scheduler/Makefile
+++ b/scheduler/Makefile
@@ -58,7 +58,7 @@ build: build-scheduler
 build.amd64: build-controller.amd64 build-scheduler.amd64
 
 .PHONY: build.arm64v8
-build.arm64v8: build-controller.arm64v8 build-scheduler.arm64v8
+build.arm64v8: build-controller.arm64v8
 
 .PHONY: build-controller
 build-controller:
@@ -114,7 +114,7 @@ local-image: clean
 build-and-push-image: release-image push-release-images
 
 .PHONY: release-image
-release-image: release-image.amd64 release-image.arm64v8
+release-image: release-image.amd64
 
 .PHONY: release-image.amd64
 release-image.amd64: clean
@@ -125,7 +125,7 @@ release-image.arm64v8: clean
 	docker build --load --build-arg ARCH="arm64v8" --build-arg RELEASE_VERSION="$(RELEASE_VERSION)" -t $(RELEASE_REGISTRY)/$(RELEASE_IMAGE)-arm64 .
 
 .PHONY: push-release-images
-push-release-images: release-image.amd64 release-image.arm64v8
+push-release-images: release-image.amd64
 	for arch in $(ARCHS); do \
 		docker push $(RELEASE_REGISTRY)/$(RELEASE_IMAGE)-$${arch} ;\
 	done
@@ -146,7 +146,7 @@ clean:
 build-and-push-local: release-local
 
 .PHONY: release-local
-release-local: release-local.amd64 release-local.arm64v8
+release-local: release-local.amd64
 	for arch in $(ARCHS); do \
 			docker push $(RELEASE_REGISTRY)/$(RELEASE_IMAGE)-$${arch} ;\
 		done


### PR DESCRIPTION
### This PR
- disables all ARM related builds for now since they probably don't work and aren't tested either
- (distroless doesn't have ARM images)