### PR TITLE
ci: Skip the remaining workflow execution if the build matrix is empty

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -83,6 +83,7 @@ jobs:
   compile:
     name: Compile
     needs: prepare_ci_run
+    if: needs.prepare_ci_run.outputs.BUILD_MATRIX_EMPTY == 'false'
     runs-on: ubuntu-20.04
     env:
       BRANCH: ${{ needs.prepare_ci_run.outputs.BRANCH }}
@@ -110,6 +111,7 @@ jobs:
   test:
     name: Unit Tests
     needs: prepare_ci_run
+    if: needs.prepare_ci_run.outputs.BUILD_MATRIX_EMPTY == 'false'
     runs-on: ubuntu-20.04
     strategy:
       matrix: ${{ fromJson(needs.prepare_ci_run.outputs.BUILD_MATRIX) }}


### PR DESCRIPTION
Signed-off-by: Philipp Hinteregger <philipp.hinteregger@dynatrace.com>

## This PR

- Skips the remaining jobs within the CI pipeline if the build matrix is empty