### PR TITLE
feat(scheduler): Background check for pod status in permit plugin

### DIFF
--- a/scheduler/cmd/scheduler/main.go
+++ b/scheduler/cmd/scheduler/main.go
@@ -29,7 +29,7 @@ func main() {
 
 	rand.Seed(time.Now().UnixNano())
 	command := app.NewSchedulerCommand(
-		app.WithPlugin(klcpermit.Name, klcpermit.New),
+		app.WithPlugin(klcpermit.PluginName, klcpermit.New),
 	)
 
 	code := cli.Run(command)

--- a/scheduler/manifests/install/base/rbac.yaml
+++ b/scheduler/manifests/install/base/rbac.yaml
@@ -69,6 +69,9 @@ rules:
   - apiGroups: ["lifecycle.keptn.sh"]
     resources: ["keptnworkloadinstances"]
     verbs: ["get", "list", "watch"]
+  - apiGroups: [ "" ]
+    resources: [ "configmaps" ]
+    verbs: [ "list", "watch" ]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/scheduler/pkg/klcpermit/permit.go
+++ b/scheduler/pkg/klcpermit/permit.go
@@ -37,10 +37,6 @@ func (pl *Permit) Permit(ctx context.Context, state *framework.CycleState, p *v1
 	// check the permit immediately, to fail early in case the pod cannot be queued
 	switch pl.workloadManager.Permit(ctx, p) {
 
-	case Wait:
-		klog.Infof("[Keptn Permit Plugin] waiting for pre-deployment checks on %s", p.GetObjectMeta().GetName())
-		go pl.monitorPod(ctx, p)
-		return framework.NewStatus(framework.Wait), 5 * time.Minute
 	case Failure:
 		klog.Infof("[Keptn Permit Plugin] failed pre-deployment checks on %s", p.GetObjectMeta().GetName())
 		return framework.NewStatus(framework.Error), 0 * time.Second
@@ -48,7 +44,8 @@ func (pl *Permit) Permit(ctx context.Context, state *framework.CycleState, p *v1
 		klog.Infof("[Keptn Permit Plugin] passed pre-deployment checks on %s", p.GetObjectMeta().GetName())
 		return framework.NewStatus(framework.Success), 0 * time.Second
 	default:
-		klog.Infof("[Keptn Permit Plugin] unknown status of pre-deployment checks for %s", p.GetObjectMeta().GetName())
+		klog.Infof("[Keptn Permit Plugin] waiting for pre-deployment checks on %s", p.GetObjectMeta().GetName())
+		go pl.monitorPod(ctx, p)
 		return framework.NewStatus(framework.Wait), 5 * time.Minute
 	}
 

--- a/scheduler/pkg/klcpermit/permit.go
+++ b/scheduler/pkg/klcpermit/permit.go
@@ -64,6 +64,7 @@ func (pl *Permit) monitorPod(ctx context.Context, p *v1.Pod) {
 		waitingPodHandler.Allow(Name)
 	default:
 		klog.Infof("[Keptn Permit Plugin] waiting pre-deployment checks for", p.GetObjectMeta().GetName())
+		time.Sleep(5 * time.Second)
 		pl.monitorPod(ctx, p)
 	}
 

--- a/scheduler/pkg/klcpermit/permit.go
+++ b/scheduler/pkg/klcpermit/permit.go
@@ -17,7 +17,7 @@ const (
 	PluginName = "KLCPermit"
 )
 
-// Permit is a plugin that waits for pre-deployment checks
+// Permit is a plugin that waits for pre-deployment checks to be successfully finished
 type Permit struct {
 	handler         framework.Handle
 	workloadManager *WorkloadManager

--- a/scheduler/pkg/klcpermit/permit.go
+++ b/scheduler/pkg/klcpermit/permit.go
@@ -17,7 +17,7 @@ const (
 	PluginName = "KLCPermit"
 )
 
-// Permit is a plugin that implements a wait for pre-deployment checks
+// Permit is a plugin that waits for pre-deployment checks
 type Permit struct {
 	handler         framework.Handle
 	workloadManager *WorkloadManager
@@ -32,10 +32,10 @@ func (pl *Permit) Name() string {
 
 func (pl *Permit) Permit(ctx context.Context, state *framework.CycleState, p *v1.Pod, nodeName string) (*framework.Status, time.Duration) {
 
-	klog.Infof("[Keptn Permit Plugin] waiting for pre-deployment checks on", p.GetObjectMeta().GetName())
+	klog.Infof("[Keptn Permit Plugin] waiting for pre-deployment checks on %s", p.GetObjectMeta().GetName())
+
 	//start async CRD monitoring
 	go pl.monitorPod(ctx, p)
-
 	//queue pod and set eviction deadline
 	return framework.NewStatus(framework.Wait), 5 * time.Minute
 


### PR DESCRIPTION
Permit plugin should check the waiting queue and reject or approve pods before the eviction

This is for now implemented as a recursive async routine.
A little learning: we cannot queue pod by default, if there is an error due to the pod being evicted etc. the queue action may fail and the scheduler could end up looping indefinitely 
