### PR TITLE
fix(scheduler): Create new context when starting background routine for pod checks

### DIFF
--- a/scheduler/pkg/klcpermit/permit.go
+++ b/scheduler/pkg/klcpermit/permit.go
@@ -45,7 +45,12 @@ func (pl *Permit) Permit(ctx context.Context, state *framework.CycleState, p *v1
 		return framework.NewStatus(framework.Success), 0 * time.Second
 	default:
 		klog.Infof("[Keptn Permit Plugin] waiting for pre-deployment checks on %s", p.GetObjectMeta().GetName())
-		go pl.monitorPod(ctx, p)
+		go func() {
+			// create a new context since we are in a new goroutine
+			ctx2, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			pl.monitorPod(ctx2, p)
+		}()
 		return framework.NewStatus(framework.Wait), 5 * time.Minute
 	}
 


### PR DESCRIPTION
This PR solves the problem of running into the dynamic client's rate limiter due to the context already being cancelled outside of the permit function