### PR TITLE
chore: Updated Prometheus Network policy for granting access from lifecycle controller namespace

### DIFF
--- a/examples/observability/config/prometheus/prometheus-networkPolicy.yaml
+++ b/examples/observability/config/prometheus/prometheus-networkPolicy.yaml
@@ -29,6 +29,13 @@ spec:
     ports:
     - port: 9090
       protocol: TCP
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: keptn-lifecycle-controller-system
+    ports:
+      - port: 9090
+        protocol: TCP
   podSelector:
     matchLabels:
       app.kubernetes.io/component: prometheus


### PR DESCRIPTION
This PR fixes the network policy for prometheus to enable the lifecycle controller to access the Prometheus API 