### PR TITLE
feat(operator): Use Async Gauges for active KLC Entities

### DIFF
--- a/operator/api/v1alpha1/common/common.go
+++ b/operator/api/v1alpha1/common/common.go
@@ -2,6 +2,7 @@ package common
 
 import (
 	"fmt"
+	"go.opentelemetry.io/otel/metric/instrument/asyncint64"
 	"math/rand"
 
 	"go.opentelemetry.io/otel/attribute"
@@ -111,18 +112,18 @@ const PreDeploymentEvaluationCheckType CheckType = "pre-eval"
 const PostDeploymentEvaluationCheckType CheckType = "post-eval"
 
 type KeptnMeters struct {
-	TaskCount          syncint64.Counter
-	TaskDuration       syncfloat64.Histogram
-	TaskActive         syncint64.UpDownCounter
-	DeploymentCount    syncint64.Counter
-	DeploymentDuration syncfloat64.Histogram
-	DeploymentActive   syncint64.UpDownCounter
-	AppCount           syncint64.Counter
-	AppDuration        syncfloat64.Histogram
-	AppActive          syncint64.UpDownCounter
-	EvaluationCount    syncint64.Counter
-	EvaluationDuration syncfloat64.Histogram
-	EvaluationActive   syncint64.UpDownCounter
+	TaskCount             syncint64.Counter
+	TaskDuration          syncfloat64.Histogram
+	TaskActive            asyncint64.Gauge
+	DeploymentCount       syncint64.Counter
+	DeploymentDuration    syncfloat64.Histogram
+	DeploymentActiveGauge asyncint64.Gauge
+	AppCount              syncint64.Counter
+	AppDuration           syncfloat64.Histogram
+	AppActive             asyncint64.Gauge
+	EvaluationCount       syncint64.Counter
+	EvaluationDuration    syncfloat64.Histogram
+	EvaluationActive      asyncint64.Gauge
 }
 
 const (
@@ -150,4 +151,9 @@ func GenerateTaskName(checkType CheckType, taskName string) string {
 func GenerateEvaluationName(checkType CheckType, evalName string) string {
 	randomId := rand.Intn(99_999-10_000) + 10000
 	return fmt.Sprintf("%s-%s-%d", checkType, TruncateString(evalName, 27), randomId)
+}
+
+type GaugeValue struct {
+	Value      int64
+	Attributes []attribute.KeyValue
 }

--- a/operator/api/v1alpha1/common/common.go
+++ b/operator/api/v1alpha1/common/common.go
@@ -2,7 +2,6 @@ package common
 
 import (
 	"fmt"
-	"go.opentelemetry.io/otel/metric/instrument/asyncint64"
 	"math/rand"
 
 	"go.opentelemetry.io/otel/attribute"
@@ -112,18 +111,14 @@ const PreDeploymentEvaluationCheckType CheckType = "pre-eval"
 const PostDeploymentEvaluationCheckType CheckType = "post-eval"
 
 type KeptnMeters struct {
-	TaskCount             syncint64.Counter
-	TaskDuration          syncfloat64.Histogram
-	TaskActive            asyncint64.Gauge
-	DeploymentCount       syncint64.Counter
-	DeploymentDuration    syncfloat64.Histogram
-	DeploymentActiveGauge asyncint64.Gauge
-	AppCount              syncint64.Counter
-	AppDuration           syncfloat64.Histogram
-	AppActive             asyncint64.Gauge
-	EvaluationCount       syncint64.Counter
-	EvaluationDuration    syncfloat64.Histogram
-	EvaluationActive      asyncint64.Gauge
+	TaskCount          syncint64.Counter
+	TaskDuration       syncfloat64.Histogram
+	DeploymentCount    syncint64.Counter
+	DeploymentDuration syncfloat64.Histogram
+	AppCount           syncint64.Counter
+	AppDuration        syncfloat64.Histogram
+	EvaluationCount    syncint64.Counter
+	EvaluationDuration syncfloat64.Histogram
 }
 
 const (

--- a/operator/controllers/keptnappversion/controller.go
+++ b/operator/controllers/keptnappversion/controller.go
@@ -80,9 +80,7 @@ func (r *KeptnAppVersionReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		return reconcile.Result{}, fmt.Errorf("could not fetch KeptnappVersion: %+v", err)
 	}
 
-	if !appVersion.IsStartTimeSet() {
-		appVersion.SetStartTime()
-	}
+	appVersion.SetStartTime()
 
 	traceContextCarrier := propagation.MapCarrier(appVersion.Annotations)
 	ctx = otel.GetTextMapPropagator().Extract(ctx, traceContextCarrier)

--- a/operator/controllers/keptnevaluation/controller.go
+++ b/operator/controllers/keptnevaluation/controller.go
@@ -94,9 +94,7 @@ func (r *KeptnEvaluationReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 
 	semconv.AddAttributeFromEvaluation(span, *evaluation)
 
-	if !evaluation.IsStartTimeSet() {
-		evaluation.SetStartTime()
-	}
+	evaluation.SetStartTime()
 
 	if evaluation.Status.RetryCount >= evaluation.Spec.Retries {
 		r.recordEvent("Warning", evaluation, "ReconcileTimeOut", "retryCount exceeded")
@@ -180,9 +178,7 @@ func (r *KeptnEvaluationReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 func (r *KeptnEvaluationReconciler) updateFinishedEvaluationMetrics(ctx context.Context, evaluation *klcv1alpha1.KeptnEvaluation, span trace.Span) error {
 	r.recordEvent("Normal", evaluation, string(evaluation.Status.OverallStatus), "the evaluation has "+string(evaluation.Status.OverallStatus))
 
-	if !evaluation.IsEndTimeSet() {
-		evaluation.SetEndTime()
-	}
+	evaluation.SetEndTime()
 
 	err := r.Client.Status().Update(ctx, evaluation)
 	if err != nil {

--- a/operator/controllers/keptntask/controller.go
+++ b/operator/controllers/keptntask/controller.go
@@ -77,9 +77,7 @@ func (r *KeptnTaskReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 
 	semconv.AddAttributeFromTask(span, *task)
 
-	if !task.IsStartTimeSet() {
-		task.SetStartTime()
-	}
+	task.SetStartTime()
 
 	err := r.Client.Status().Update(ctx, task)
 	if err != nil {
@@ -115,10 +113,7 @@ func (r *KeptnTaskReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	r.Log.Info("Finished Reconciling KeptnTask")
 
 	// Task is completed at this place
-
-	if !task.IsEndTimeSet() {
-		task.SetEndTime()
-	}
+	task.SetEndTime()
 
 	err = r.Client.Status().Update(ctx, task)
 	if err != nil {

--- a/operator/controllers/keptnworkloadinstance/controller.go
+++ b/operator/controllers/keptnworkloadinstance/controller.go
@@ -96,9 +96,7 @@ func (r *KeptnWorkloadInstanceReconciler) Reconcile(ctx context.Context, req ctr
 
 	semconv.AddAttributeFromWorkloadInstance(span, *workloadInstance)
 
-	if !workloadInstance.IsStartTimeSet() {
-		workloadInstance.SetStartTime()
-	}
+	workloadInstance.SetStartTime()
 
 	//Wait for pre-evaluation checks of App
 	phase := common.PhaseAppPreEvaluation

--- a/operator/main.go
+++ b/operator/main.go
@@ -123,7 +123,7 @@ func main() {
 	if err != nil {
 		setupLog.Error(err, "unable to start OTel")
 	}
-	deploymentActiveGauge, err := meter.AsyncInt64().Gauge("keptn.deployment.active", instrument.WithDescription("a gauge keeping track of the currently active Keptn Tasks"))
+	deploymentActiveGauge, err := meter.AsyncInt64().Gauge("keptn.deployment.active", instrument.WithDescription("a gauge keeping track of the currently active Keptn Deployments"))
 	if err != nil {
 		setupLog.Error(err, "unable to start OTel")
 	}

--- a/operator/main.go
+++ b/operator/main.go
@@ -115,51 +115,51 @@ func main() {
 	exporter := otelprom.New()
 	provider := metric.NewMeterProvider(metric.WithReader(exporter))
 	meter := provider.Meter("keptn/task")
-	deploymentCount, err := meter.SyncInt64().Counter("keptn.deployment.count", instrument.WithDescription("a simple counter for Keptn deployment"))
+	deploymentCount, err := meter.SyncInt64().Counter("keptn.deployment.count", instrument.WithDescription("a simple counter for Keptn Deployments"))
 	if err != nil {
 		setupLog.Error(err, "unable to start OTel")
 	}
-	deploymentDuration, err := meter.SyncFloat64().Histogram("keptn.deployment.duration", instrument.WithDescription("a histogram of duration for Keptn deployment"), instrument.WithUnit(unit.Unit("s")))
+	deploymentDuration, err := meter.SyncFloat64().Histogram("keptn.deployment.duration", instrument.WithDescription("a histogram of duration for Keptn Deployments"), instrument.WithUnit(unit.Unit("s")))
 	if err != nil {
 		setupLog.Error(err, "unable to start OTel")
 	}
-	deploymentActiveGauge, err := meter.AsyncInt64().Gauge("keptn.deployment.active", instrument.WithDescription("a gauge keeping track of the currently active tasks for a Keptn deployment"))
+	deploymentActiveGauge, err := meter.AsyncInt64().Gauge("keptn.deployment.active", instrument.WithDescription("a gauge keeping track of the currently active Keptn Tasks"))
 	if err != nil {
 		setupLog.Error(err, "unable to start OTel")
 	}
-	taskCount, err := meter.SyncInt64().Counter("keptn.task.count", instrument.WithDescription("a simple counter for Keptn tasks"))
+	taskCount, err := meter.SyncInt64().Counter("keptn.task.count", instrument.WithDescription("a simple counter for Keptn Tasks"))
 	if err != nil {
 		setupLog.Error(err, "unable to start OTel")
 	}
-	taskDuration, err := meter.SyncFloat64().Histogram("keptn.task.duration", instrument.WithDescription("a histogram of duration for Keptn tasks"), instrument.WithUnit(unit.Unit("s")))
+	taskDuration, err := meter.SyncFloat64().Histogram("keptn.task.duration", instrument.WithDescription("a histogram of duration for Keptn Tasks"), instrument.WithUnit(unit.Unit("s")))
 	if err != nil {
 		setupLog.Error(err, "unable to start OTel")
 	}
-	taskActiveGauge, err := meter.AsyncInt64().Gauge("keptn.task.active", instrument.WithDescription("a simple counter of active Keptn tasks"))
+	taskActiveGauge, err := meter.AsyncInt64().Gauge("keptn.task.active", instrument.WithDescription("a simple counter of active Keptn Tasks"))
 	if err != nil {
 		setupLog.Error(err, "unable to start OTel")
 	}
-	appCount, err := meter.SyncInt64().Counter("keptn.app.count", instrument.WithDescription("a simple counter for Keptn apps"))
+	appCount, err := meter.SyncInt64().Counter("keptn.app.count", instrument.WithDescription("a simple counter for Keptn Apps"))
 	if err != nil {
 		setupLog.Error(err, "unable to start OTel")
 	}
-	appDuration, err := meter.SyncFloat64().Histogram("keptn.app.duration", instrument.WithDescription("a histogram of duration for Keptn apps"), instrument.WithUnit(unit.Unit("s")))
+	appDuration, err := meter.SyncFloat64().Histogram("keptn.app.duration", instrument.WithDescription("a histogram of duration for Keptn Apps"), instrument.WithUnit(unit.Unit("s")))
 	if err != nil {
 		setupLog.Error(err, "unable to start OTel")
 	}
-	appActiveGauge, err := meter.AsyncInt64().Gauge("keptn.app.active", instrument.WithDescription("a simple counter of active apps for Keptn apps"))
+	appActiveGauge, err := meter.AsyncInt64().Gauge("keptn.app.active", instrument.WithDescription("a simple counter of active Keptn Apps"))
 	if err != nil {
 		setupLog.Error(err, "unable to start OTel")
 	}
-	evaluationCount, err := meter.SyncInt64().Counter("keptn.evaluation.count", instrument.WithDescription("a simple counter for Keptn evaluation for Evaluations"))
+	evaluationCount, err := meter.SyncInt64().Counter("keptn.evaluation.count", instrument.WithDescription("a simple counter for Keptn Evaluations"))
 	if err != nil {
 		setupLog.Error(err, "unable to start OTel")
 	}
-	evaluationDuration, err := meter.SyncFloat64().Histogram("keptn.evaluation.duration", instrument.WithDescription("a histogram of duration for Keptn evaluation for Evaluations"), instrument.WithUnit(unit.Unit("s")))
+	evaluationDuration, err := meter.SyncFloat64().Histogram("keptn.evaluation.duration", instrument.WithDescription("a histogram of duration for Keptn Evaluations"), instrument.WithUnit(unit.Unit("s")))
 	if err != nil {
 		setupLog.Error(err, "unable to start OTel")
 	}
-	evaluationActiveGauge, err := meter.AsyncInt64().Gauge("keptn.evaluation.active", instrument.WithDescription("a simple counter of active apps for Keptn evaluation for Evaluations"))
+	evaluationActiveGauge, err := meter.AsyncInt64().Gauge("keptn.evaluation.active", instrument.WithDescription("a simple counter of active Keptn Evaluations"))
 	if err != nil {
 		setupLog.Error(err, "unable to start OTel")
 	}

--- a/operator/main.go
+++ b/operator/main.go
@@ -165,18 +165,14 @@ func main() {
 	}
 
 	meters := common.KeptnMeters{
-		TaskCount:             taskCount,
-		TaskDuration:          taskDuration,
-		TaskActive:            taskActiveGauge,
-		DeploymentCount:       deploymentCount,
-		DeploymentDuration:    deploymentDuration,
-		DeploymentActiveGauge: deploymentActiveGauge,
-		AppCount:              appCount,
-		AppDuration:           appDuration,
-		AppActive:             appActiveGauge,
-		EvaluationCount:       evaluationCount,
-		EvaluationDuration:    evaluationDuration,
-		EvaluationActive:      evaluationActiveGauge,
+		TaskCount:          taskCount,
+		TaskDuration:       taskDuration,
+		DeploymentCount:    deploymentCount,
+		DeploymentDuration: deploymentDuration,
+		AppCount:           appCount,
+		AppDuration:        appDuration,
+		EvaluationCount:    evaluationCount,
+		EvaluationDuration: evaluationDuration,
 	}
 
 	// Start the prometheus HTTP server and pass the exporter Collector to it


### PR DESCRIPTION
Closes #203 
This makes sure that the number of active deployments/tasks/evaluations/apps stays consistent and there are not leftover counter values.

Example for active deployments in Grafana:

![Screenshot 2022-10-20 at 14 35 59](https://user-images.githubusercontent.com/2143586/196952791-3a8fed60-6aca-41c6-9261-15509d1246f8.png)

Signed-off-by: Florian Bacher <florian.bacher@dynatrace.com>